### PR TITLE
Dev fix for overlapping hp bar

### DIFF
--- a/DisplayPlayerStats/ModEntry.cs
+++ b/DisplayPlayerStats/ModEntry.cs
@@ -38,7 +38,7 @@ namespace ModSandbox
 			}
 
 			// Log every 180 ticks (roughly 3 seconds)
-			//TickLogger();
+			TickLogger();
 		}
 
 		public void TickLogger()
@@ -49,7 +49,7 @@ namespace ModSandbox
 			{
 				// Place debug logs here - leaving some commented as they are good reference
 				//Monitor.Log($"OnRenderingHudCalled - zoomLevel: {Game1.options.zoomLevel} - WxH: {Game1.viewport.Width}x{Game1.viewport.Height}", LogLevel.Debug);
-				//Monitor.Log($"SafeArea WxH: {testSafeArea.Width}x{testSafeArea.Height}", LogLevel.Debug);
+				//Monitor.Log($"health: {player.health} - maxHealth: {player.maxHealth}", LogLevel.Debug);
 				//Monitor.Log($"SafeArea TxB: {testSafeArea.Top}x{testSafeArea.Bottom}", LogLevel.Debug);
 				//Monitor.Log($"SafeArea LxR: {testSafeArea.Left}x{testSafeArea.Right}", LogLevel.Debug);
 				tickCount = 0;

--- a/DisplayPlayerStats/ModEntry.cs
+++ b/DisplayPlayerStats/ModEntry.cs
@@ -38,7 +38,7 @@ namespace ModSandbox
 			}
 
 			// Log every 180 ticks (roughly 3 seconds)
-			TickLogger();
+			//TickLogger();
 		}
 
 		public void TickLogger()

--- a/DisplayPlayerStats/UpdateHud.cs
+++ b/DisplayPlayerStats/UpdateHud.cs
@@ -39,25 +39,35 @@ namespace ModSandbox
 			// Scale up the icons
 			int destWxH = (int)(modConstants.statusIconWxH * modConstants.scaleFactor);
 
-			// Calculate position for image based on the text position and current game location
-			switch (Game1.currentLocation)
+			if (player.health != player.maxHealth)
 			{
-				case MineShaft _:
-				case Woods _:
-				case SlimeHutch _:
-				case VolcanoDungeon _:
-					destStaminaRect = new Rectangle(statusIconsDestX, staminaDestY, destWxH, destWxH);
-					destHealthRect = new Rectangle(statusIconsDestX, healthDestY, destWxH, destWxH);
-					staminaTextPosition = new Vector2(statusTextX, staminaDestY);
-					healthTextPosition = new Vector2(statusTextX, healthDestY);
-				break;
-				default:
-					destStaminaRect = new Rectangle(statusIconsDestX + modConstants.healthBarOffset, staminaDestY, destWxH, destWxH);
-					destHealthRect = new Rectangle(statusIconsDestX + modConstants.healthBarOffset, healthDestY, destWxH, destWxH);
-					staminaTextPosition = new Vector2(statusTextX + modConstants.healthBarOffset, staminaDestY);
-					healthTextPosition = new Vector2(statusTextX + modConstants.healthBarOffset, healthDestY);
-				break;
-			}
+                destStaminaRect = new Rectangle(statusIconsDestX, staminaDestY, destWxH, destWxH);
+                destHealthRect = new Rectangle(statusIconsDestX, healthDestY, destWxH, destWxH);
+                staminaTextPosition = new Vector2(statusTextX, staminaDestY);
+                healthTextPosition = new Vector2(statusTextX, healthDestY);
+            }
+			else
+			{
+				// Calculate position for image based on the text position and current game location
+				switch (Game1.currentLocation)
+				{
+					case MineShaft _:
+					case Woods _:
+					case SlimeHutch _:
+					case VolcanoDungeon _:
+						destStaminaRect = new Rectangle(statusIconsDestX, staminaDestY, destWxH, destWxH);
+						destHealthRect = new Rectangle(statusIconsDestX, healthDestY, destWxH, destWxH);
+						staminaTextPosition = new Vector2(statusTextX, staminaDestY);
+						healthTextPosition = new Vector2(statusTextX, healthDestY);
+						break;
+					default:
+                        destStaminaRect = new Rectangle(statusIconsDestX + modConstants.healthBarOffset, staminaDestY, destWxH, destWxH);
+                        destHealthRect = new Rectangle(statusIconsDestX + modConstants.healthBarOffset, healthDestY, destWxH, destWxH);
+                        staminaTextPosition = new Vector2(statusTextX + modConstants.healthBarOffset, staminaDestY);
+                        healthTextPosition = new Vector2(statusTextX + modConstants.healthBarOffset, healthDestY);
+                        break;
+				}
+            }
 
 			// Draw value and icon to the screen
 			SpriteBatch spriteBatch = e.SpriteBatch;

--- a/DisplayPlayerStats/UpdateHud.cs
+++ b/DisplayPlayerStats/UpdateHud.cs
@@ -39,32 +39,24 @@ namespace ModSandbox
 			// Scale up the icons
 			int destWxH = (int)(modConstants.statusIconWxH * modConstants.scaleFactor);
 
+			// Draw icons in altered position if the player has less than MaxHP
 			if (player.health != player.maxHealth)
 			{
-                destStaminaRect = new Rectangle(statusIconsDestX, staminaDestY, destWxH, destWxH);
-                destHealthRect = new Rectangle(statusIconsDestX, healthDestY, destWxH, destWxH);
-                staminaTextPosition = new Vector2(statusTextX, staminaDestY);
-                healthTextPosition = new Vector2(statusTextX, healthDestY);
+				SetIconDrawPos(statusIconsDestX, staminaDestY, healthDestY, destWxH, statusTextX, staminaDestY, healthDestY);
             }
 			else
 			{
-				// Calculate position for image based on the text position and current game location
+				// Draw icons in a different place if on full HP and in one of the locations where the health bar spawns
 				switch (Game1.currentLocation)
 				{
 					case MineShaft _:
 					case Woods _:
 					case SlimeHutch _:
 					case VolcanoDungeon _:
-						destStaminaRect = new Rectangle(statusIconsDestX, staminaDestY, destWxH, destWxH);
-						destHealthRect = new Rectangle(statusIconsDestX, healthDestY, destWxH, destWxH);
-						staminaTextPosition = new Vector2(statusTextX, staminaDestY);
-						healthTextPosition = new Vector2(statusTextX, healthDestY);
+					SetIconDrawPos(statusIconsDestX, staminaDestY, healthDestY, destWxH, statusTextX, staminaDestY, healthDestY);
 						break;
 					default:
-                        destStaminaRect = new Rectangle(statusIconsDestX + modConstants.healthBarOffset, staminaDestY, destWxH, destWxH);
-                        destHealthRect = new Rectangle(statusIconsDestX + modConstants.healthBarOffset, healthDestY, destWxH, destWxH);
-                        staminaTextPosition = new Vector2(statusTextX + modConstants.healthBarOffset, staminaDestY);
-                        healthTextPosition = new Vector2(statusTextX + modConstants.healthBarOffset, healthDestY);
+					SetIconDrawPos(statusIconsDestX + modConstants.healthBarOffset, staminaDestY, healthDestY, destWxH, statusTextX + modConstants.healthBarOffset, staminaDestY, healthDestY);
                         break;
 				}
             }
@@ -75,6 +67,14 @@ namespace ModSandbox
 			spriteBatch.Draw(tileSheet, destStaminaRect, sourceStaminaRect, Color.White);
 			spriteBatch.DrawString(Game1.smallFont, $"{currentHealth}", healthTextPosition, Color.White);
 			spriteBatch.Draw(tileSheet, destHealthRect, sourceHealthRect, Color.White);
+		}
+
+		private void SetIconDrawPos(int xPosIcon, int yPosStamina, int YPosHealth, int destWxH, int statusTextX, int staminaDestY, int healthDestY)
+		{
+			destStaminaRect = new Rectangle(xPosIcon, yPosStamina, destWxH, destWxH);
+			destHealthRect = new Rectangle(xPosIcon, YPosHealth, destWxH, destWxH);
+			staminaTextPosition = new Vector2(statusTextX, staminaDestY);
+			healthTextPosition = new Vector2(statusTextX, healthDestY);
 		}
 	}
 }


### PR DESCRIPTION
Fixed bug where text and icon would show beneath the health bar if not on full hp outside of the mineshaft